### PR TITLE
Corrected theme link

### DIFF
--- a/ExplainToMe/templates/base.html
+++ b/ExplainToMe/templates/base.html
@@ -24,7 +24,7 @@
 
     {% block styles %}
         <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" />
-        <link href="https://bootswatch.com/readable/bootstrap.min.css" rel="stylesheet" />
+        <link href="https://bootswatch.com/3/readable/bootstrap.min.css" rel="stylesheet" />
         <link href="{{ url_for('static', filename='css/style.css') }}" rel=stylesheet />
         <link href="{{ url_for('static', filename='css/animation.css') }}" rel=stylesheet />
     {% endblock styles %}


### PR DESCRIPTION
Corrected theme link
from https://bootswatch.com/readable/bootstrap.min.css
to https://bootswatch.com/3/readable/bootstrap.min.css
as readable themes moved to legacy.
Also redeployed it on 
https://explaintome.herokuapp.com