### PR TITLE
Repository name must be lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you are getting started on OS X, the [Docker toolbox](https://docs.docker.com
 is the first thing to checkout.
 
 ```bash
-$ docker run -it -p 5000:5000 jjangsangy/ExplainToMe:latest
+$ docker run -it -p 5000:5000 jjangsangy/explaintome:latest
 ```
 
 Once the server is running, navigate to either localhost:5000 (on Linux) or


### PR DESCRIPTION
Docker doesn't allow to use Uppercase characters.

Before: 
```
% docker run -it -p 5000:5000 jjangsangy/ExplainToMe:latest
docker: invalid reference format: repository name must be lowercase.
See 'docker run --help'.
```

After: 
```
% docker run -it -p 5000:5000 jjangsangy/explaintome:latest
Unable to find image 'jjangsangy/explaintome:latest' locally
latest: Pulling from jjangsangy/explaintome
81033e7c1d6a: Pull complete
...
```